### PR TITLE
Upgrade GitHub Actions runner to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'Pull Request repo in owner/repo format'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
**Change**
Upgrade GitHub Actions runner to Node.js 24

**Why?**
GitHub has officially deprecated Node.js 20 for actions. Starting June 2, 2026, all actions will be forced to run on Node.js 24.